### PR TITLE
 Fix header icon on iOS

### DIFF
--- a/styles/themes/theme-leedsPHR/blocks/main/header/_header-buttons.scss
+++ b/styles/themes/theme-leedsPHR/blocks/main/header/_header-buttons.scss
@@ -7,7 +7,18 @@
 }
 .btn-header-prev {
   width: $header-height;
+  text-align: center;
   background: #1993EF;
-    color: #fff;
-    font-size: 26px;
+  color: #fff;
+  font-size: 26px;
+  position: relative;
+
+  /* Icon not centering on iOS, css fix applied below to absolute position */
+  i {
+    display: block;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 15px;
+  }
 }


### PR DESCRIPTION
Absolute positioned the header icon to force positioning within the middle of the header button.